### PR TITLE
Add quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,41 @@ Quartz v4 features a from-the-ground rewrite focusing on end-user extensibility 
     <img src="https://cdn.jsdelivr.net/gh/jackyzha0/jackyzha0/sponsorkit/sponsors.svg" />
   </a>
 </p>
+
+## 🪴 Get Started
+
+Quartz requires **at least Node v22** and `npm` v10.9.2 to function correctly. Ensure these are installed before continuing.
+
+```bash
+git clone https://github.com/jackyzha0/quartz.git
+cd quartz
+npm i
+npx quartz create
+```
+
+This will guide you through initializing your Quartz with content. Once you've done so, you can:
+
+1. Write content in Quartz
+2. Configure Quartz's behaviour
+3. Change Quartz's layout
+4. Build and preview Quartz
+5. Sync your changes with GitHub
+6. Host Quartz online
+
+If you prefer instructions in a video format, you can follow [Nicole van der Hoeven's video guide](https://www.youtube.com/watch?v=6s6DT1yN4dw&t=227s).
+
+## 🔧 Features
+
+- Obsidian compatibility, full-text search, graph view, wikilinks, transclusions, backlinks, Latex, syntax highlighting, popover previews, Docker Support, internationalization, comments and many more right out of the box
+- Hot-reload on configuration edits and incremental rebuilds for content edits
+- Simple JSX layouts and page components
+- Ridiculously fast page loads and tiny bundle sizes
+- Fully-customizable parsing, filtering, and page generation through plugins
+
+For a comprehensive list of features, visit the [features page](docs/features/). You can read more about the _why_ behind these features on the [philosophy](docs/philosophy.md) page and a technical overview on the [architecture](docs/advanced/architecture.md) page.
+
+### 🚧 Troubleshooting + Updating
+
+Having trouble with Quartz? Try searching for your issue using the search feature. If you haven't already, upgrade to the newest version of Quartz to see if this fixes your issue.
+
+If you're still having trouble, feel free to submit an issue or ask for help in our [Discord Community](https://discord.gg/cRFFHYye7t).


### PR DESCRIPTION
## Summary
- update README with quickstart usage instructions

## Testing
- `npm run check` *(fails: Cannot find module 'util' or its corresponding type declarations)*
- `npm i` *(fails: EBADENGINE, Node 22+ required)*

------
https://chatgpt.com/codex/tasks/task_e_688ba2bfe1d08326a216dc2bee16b3f0