### PR TITLE
Fix spaPreserve flag for inline styles

### DIFF
--- a/quartz/util/resources.tsx
+++ b/quartz/util/resources.tsx
@@ -46,7 +46,7 @@ export function JSResourceToScriptElement(resource: JSResource, preserve?: boole
 export function CSSResourceToStyleElement(resource: CSSResource, preserve?: boolean): JSX.Element {
   const spaPreserve = preserve ?? resource.spaPreserve
   if (resource.inline ?? false) {
-    return <style>{resource.content}</style>
+    return <style spa-preserve={spaPreserve}>{resource.content}</style>
   } else {
     return (
       <link


### PR DESCRIPTION
## Summary
- include `spa-preserve` on inline `<style>` tags
- keep existing behavior for external stylesheets

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ba8ba903c8326b85ebfd9dcdc6afd