### PR TITLE
Load environment variables from .env.local

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,1 @@
+TOKEN=your_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ tsconfig.tsbuildinfo
 private/
 .replit
 replit.nix
+.env.local
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ Quartz v4 features a from-the-ground rewrite focusing on end-user extensibility 
 
 [Join the Discord Community](https://discord.gg/cRFFHYye7t)
 
+## Environment Variables
+
+Quartz reads configuration from an optional `.env.local` file at runtime. Use
+this file to provide API tokens or other secrets that shouldn't be committed to
+version control. A sample file is provided as `.env.local.example`:
+
+```env
+TOKEN=your_token_here
+```
+
 ## Sponsors
 
 <p align="center">

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "chokidar": "^4.0.3",
         "cli-spinner": "^0.2.10",
         "d3": "^7.9.0",
+        "dotenv": "^16.4.5",
         "esbuild-sass-plugin": "^3.3.1",
         "flexsearch": "0.7.43",
         "github-slugger": "^2.0.0",
@@ -2919,6 +2920,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/earcut": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "chokidar": "^4.0.3",
     "cli-spinner": "^0.2.10",
     "d3": "^7.9.0",
+    "dotenv": "^16.4.5",
     "esbuild-sass-plugin": "^3.3.1",
     "flexsearch": "0.7.43",
     "github-slugger": "^2.0.0",

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env -S node --no-deprecation
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
+import { config as loadEnv } from "dotenv"
+loadEnv({ path: ".env.local" })
 import {
   handleBuild,
   handleCreate,

--- a/quartz/bootstrap-worker.mjs
+++ b/quartz/bootstrap-worker.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import workerpool from "workerpool"
+import { config as loadEnv } from "dotenv"
+loadEnv({ path: ".env.local" })
 const cacheFile = "./.quartz-cache/transpiled-worker.mjs"
 const { parseMarkdown, processHtml } = await import(cacheFile)
 workerpool.worker({


### PR DESCRIPTION
## Summary
- add `dotenv` dependency
- load variables from `.env.local` in CLI and worker
- ignore `.env.local` and provide `.env.local.example`
- document env file usage

## Testing
- `npm test`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_688bd458afa48326a513a2ffd47b1d4a