### PR TITLE
Fix missing env.js

### DIFF
--- a/quartz/util/env.js
+++ b/quartz/util/env.js
@@ -1,0 +1,7 @@
+import { config } from "dotenv";
+
+// Load environment variables from .env.local if present
+config({ path: ".env.local" });
+
+/** API token loaded from `.env.local` */
+export const APIToken = process.env.TOKEN || "";


### PR DESCRIPTION
## Summary
- add the compiled `util/env.js` used by the CLI

## Testing
- `npm test`
- `node quartz/bootstrap-cli.mjs sync` *(fails to sync due to missing git remote but no module error)*

------
https://chatgpt.com/codex/tasks/task_e_688bedb7d7b48326b0996fd1d0dd4d35