### PR TITLE
Fix werent typo

### DIFF
--- a/quartz/cli/handlers.js
+++ b/quartz/cli/handlers.js
@@ -104,7 +104,7 @@ export async function handleCreate(argv) {
     }
   }
 
-  // Use cli process if cmd args werent provided
+  // Use cli process if cmd args weren’t provided
   if (!setupStrategy) {
     setupStrategy = exitIfCancel(
       await select({
@@ -181,7 +181,7 @@ See the [documentation](https://quartz.jzhao.xyz) for how to get started.
     )
   }
 
-  // Use cli process if cmd args werent provided
+  // Use cli process if cmd args weren’t provided
   if (!linkResolutionStrategy) {
     // get a preferred link resolution strategy
     linkResolutionStrategy = exitIfCancel(


### PR DESCRIPTION
## Summary
- fix 'werent' typo in `quartz/cli/handlers.js`

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c3738e0dc8326b098f236f7d31f88