### PR TITLE
Fix escapePath regex and add tests

### DIFF
--- a/quartz/cli/helpers.js
+++ b/quartz/cli/helpers.js
@@ -7,8 +7,8 @@ import fs from "fs"
 export function escapePath(fp) {
   return fp
     .replace(/\\ /g, " ") // unescape spaces
-    .replace(/^".*"$/, "$1")
-    .replace(/^'.*"$/, "$1")
+    .replace(/^"(.*)"$/, "$1")
+    .replace(/^'(.*)'$/, "$1")
     .trim()
 }
 

--- a/quartz/cli/helpers.test.ts
+++ b/quartz/cli/helpers.test.ts
@@ -1,0 +1,15 @@
+import test from "node:test"
+import assert from "node:assert"
+import { escapePath } from "./helpers.js"
+
+test("unquotes double quoted paths", () => {
+  assert.strictEqual(escapePath('"a/b"'), "a/b")
+})
+
+test("unquotes single quoted paths", () => {
+  assert.strictEqual(escapePath("'a/b'"), "a/b")
+})
+
+test("unescapes spaces", () => {
+  assert.strictEqual(escapePath("a\\\ b"), "a b")
+})


### PR DESCRIPTION
## Summary
- fix regex patterns in `escapePath`
- add tests for quoted path handling

## Testing
- `npx tsx --test quartz/**/*.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_688c373ff074832685d69b2f8040a423