### PR TITLE
Fix example default options in docs

### DIFF
--- a/docs/advanced/creating components.md
+++ b/docs/advanced/creating components.md
@@ -40,7 +40,7 @@ const defaultOptions: Options = {
 }
 
 export default ((userOpts?: Options) => {
-  const opts = { ...userOpts, ...defaultOpts }
+  const opts = { ...userOpts, ...defaultOptions }
   function YourComponent(props: QuartzComponentProps) {
     if (opts.favouriteNumber < 0) {
       return null


### PR DESCRIPTION
## Summary
- correct `defaultOpts` reference in component example

## Testing
- `npm run check` *(fails: Cannot find module 'util' or its corresponding type declarations)*
- `npm test` *(fails: `tsx` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c3744d90883269c2f6b56af4fd6c9