### PR TITLE
Add edge case tests for joinSegments

### DIFF
--- a/quartz/util/path.test.ts
+++ b/quartz/util/path.test.ts
@@ -187,6 +187,10 @@ describe("transforms", () => {
     assert.strictEqual(path.joinSegments("/a/", "b", "/"), "/a/b/")
     assert.strictEqual(path.joinSegments("a/", "b" + "/"), "a/b/")
 
+    // empty segments
+    assert.strictEqual(path.joinSegments("", "/"), "/")
+    assert.strictEqual(path.joinSegments("/", ""), "/")
+
     // works with protocol specifiers
     assert.strictEqual(path.joinSegments("https://example.com", "a"), "https://example.com/a")
     assert.strictEqual(path.joinSegments("https://example.com/", "a"), "https://example.com/a")


### PR DESCRIPTION
## Summary
- add tests for joinSegments with empty segments

## Testing
- `npx tsx --test quartz/util/path.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_688c374c8c2c8326a5591b5ddfc70e50