### PR TITLE
Add GitHub Pages troubleshooting docs

### DIFF
--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -121,6 +121,16 @@ See the [GitHub documentation](https://docs.github.com/en/pages/configuring-a-cu
 >
 > Make sure you save your changes to Git and sync it to GitHub by doing `npx quartz sync`. This will also make sure to pull any updates you may have made from other devices so you have them locally.
 
+### Troubleshooting GitHub Pages
+
+If your site isn't appearing or updates aren't showing, check the following:
+
+- **Workflow errors**: open the GitHub Actions tab and confirm the deploy workflow completed without errors.
+- **Incorrect `baseUrl`**: `baseUrl` in `quartz.config.ts` should match your Pages URL or custom domain.
+- **Misconfigured Pages source**: under your repository settings → Pages, ensure the source is set to **GitHub Actions**.
+- **Missing `.nojekyll`**: ensure the generated `public` directory includes a `.nojekyll` file so asset folders starting with `_` are served.
+
+
 ## Vercel
 
 ### Fix URLs

--- a/docs/setting up your GitHub repository.md
+++ b/docs/setting up your GitHub repository.md
@@ -61,3 +61,4 @@ In future updates, you can simply run `npx quartz sync` every time you want to p
 > - `--commit` or `--no-commit`: whether to make a `git` commit for your changes
 > - `--push` or `--no-push`: whether to push updates to your GitHub fork of Quartz
 > - `--pull` or `--no-pull`: whether to try and pull in any updates from your GitHub fork (i.e. from other devices) before pushing
+For help debugging deployments, see [[hosting#Troubleshooting GitHub Pages|Troubleshooting GitHub Pages]].


### PR DESCRIPTION
## Summary
- add a troubleshooting section for GitHub Pages
- link to the troubleshooting section from the setup docs

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c395efd4c832682a3ca351eb4a11a