### PR TITLE
Fix .nojekyll emitter

### DIFF
--- a/content/Blog/2025-07-31.md
+++ b/content/Blog/2025-07-31.md
@@ -2,7 +2,7 @@
 title: 2025-07-31
 draft: true
 date: 2025-07-31T19:24:00
-published: ""
+published: 2025-07-31T19:24:00
 tags:
   - blog
 ---

--- a/quartz/plugins/emitters/nojekyll.test.ts
+++ b/quartz/plugins/emitters/nojekyll.test.ts
@@ -1,0 +1,40 @@
+import test, { describe } from "node:test"
+import assert from "node:assert"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { NoJekyll } from "./nojekyll"
+import { joinSegments } from "../../util/path"
+import { Argv, BuildCtx } from "../../util/ctx"
+import { QuartzConfig } from "../../cfg"
+
+describe("NoJekyll emitter", () => {
+  const makeCtx = async () => {
+    const output = path.join(await fs.mkdtemp(path.join(os.tmpdir(), "quartz-")), "out")
+    const argv: Argv = {
+      directory: "",
+      verbose: false,
+      output,
+      serve: false,
+      watch: false,
+      port: 0,
+      wsPort: 0,
+    }
+    const cfg: QuartzConfig = {
+      configuration: {} as any,
+      plugins: { transformers: [], filters: [], emitters: [] },
+    } as any
+    return { ctx: { argv, cfg } as BuildCtx, output }
+  }
+
+  test("creates .nojekyll file even when output directory is missing", async () => {
+    const { ctx, output } = await makeCtx()
+    const plugin = NoJekyll()
+    const files = await plugin.emit(ctx as any, [] as any, {} as any)
+    const expected = joinSegments(output, ".nojekyll")
+    assert.deepStrictEqual(files, [expected])
+    const content = await fs.readFile(expected, "utf8")
+    assert.strictEqual(content, "")
+    await fs.rm(path.dirname(output), { recursive: true, force: true })
+  })
+})

--- a/quartz/plugins/emitters/nojekyll.ts
+++ b/quartz/plugins/emitters/nojekyll.ts
@@ -10,6 +10,9 @@ export const NoJekyll: QuartzEmitterPlugin = () => ({
   name: "NoJekyll",
   async emit({ argv }) {
     const outputFile = joinSegments(argv.output, ".nojekyll")
+    // ensure the output directory exists since emitters run concurrently
+    // and the directory may not have been created yet
+    await fs.promises.mkdir(argv.output, { recursive: true })
     await fs.promises.writeFile(outputFile, "")
     return [outputFile] as FilePath[]
   },


### PR DESCRIPTION
## Summary
- ensure `.nojekyll` emitter creates the output folder
- fix frontmatter date warning in sample post
- add regression test for `.nojekyll` emitter

## Testing
- `npm install --engine-strict=false`
- `npx tsx --test quartz/plugins/emitters/nojekyll.test.ts`
- `node quartz/bootstrap-cli.mjs build --serve` *(fails: fetch failed from CustomOgImages)*

------
https://chatgpt.com/codex/tasks/task_e_688c3df8c5c483269b18b14a8e706af7