### PR TITLE
Add module comments across Quartz files

### DIFF
--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -1,3 +1,10 @@
+/**
+ * Main build entry point for Quartz.
+ *
+ * Handles Markdown parsing, plugin execution, and file emission.
+ * When run in watch mode it also monitors the content directory and
+ * triggers incremental rebuilds.
+ */
 import sourceMapSupport from "source-map-support"
 sourceMapSupport.install(options)
 import path from "path"

--- a/quartz/components/ArticleTitle.tsx
+++ b/quartz/components/ArticleTitle.tsx
@@ -1,3 +1,6 @@
+/**
+ * Renders the title of a note as an `<h1>` element.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import { classNames } from "../util/lang"
 

--- a/quartz/components/Backlinks.tsx
+++ b/quartz/components/Backlinks.tsx
@@ -1,3 +1,6 @@
+/**
+ * Lists other notes that link back to the current one.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import style from "./styles/backlinks.scss"
 import { resolveRelative, simplifySlug } from "../util/path"

--- a/quartz/components/Body.tsx
+++ b/quartz/components/Body.tsx
@@ -1,3 +1,6 @@
+/**
+ * Wrapper for the main article body that also injects clipboard behaviour.
+ */
 // @ts-ignore
 import clipboardScript from "./scripts/clipboard.inline"
 import clipboardStyle from "./styles/clipboard.scss"

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -1,3 +1,6 @@
+/**
+ * Displays a breadcrumb trail for the current note location.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import breadcrumbsStyle from "./styles/breadcrumbs.scss"
 import { FullSlug, SimpleSlug, resolveRelative, simplifySlug } from "../util/path"

--- a/quartz/components/Comments.tsx
+++ b/quartz/components/Comments.tsx
@@ -1,3 +1,6 @@
+/**
+ * Embeds a comment section using the configured third-party provider.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import { classNames } from "../util/lang"
 // @ts-ignore

--- a/quartz/components/ConditionalRender.tsx
+++ b/quartz/components/ConditionalRender.tsx
@@ -1,3 +1,6 @@
+/**
+ * Higher-order component that only renders its child when a condition holds.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 
 type ConditionalRenderConfig = {

--- a/quartz/components/ContentMeta.tsx
+++ b/quartz/components/ContentMeta.tsx
@@ -1,3 +1,6 @@
+/**
+ * Displays article metadata such as publish date and reading time.
+ */
 import { Date, getDate } from "./Date"
 import { QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import readingTime from "reading-time"

--- a/quartz/components/Darkmode.tsx
+++ b/quartz/components/Darkmode.tsx
@@ -1,3 +1,6 @@
+/**
+ * Toggle button for switching between light and dark themes.
+ */
 // @ts-ignore
 import darkmodeScript from "./scripts/darkmode.inline"
 import styles from "./styles/darkmode.scss"

--- a/quartz/components/Date.tsx
+++ b/quartz/components/Date.tsx
@@ -1,3 +1,6 @@
+/**
+ * Helper component for formatting dates according to locale settings.
+ */
 import { GlobalConfiguration } from "../cfg"
 import { ValidLocale } from "../i18n"
 import { QuartzPluginData } from "../plugins/vfile"

--- a/quartz/components/DesktopOnly.tsx
+++ b/quartz/components/DesktopOnly.tsx
@@ -1,3 +1,6 @@
+/**
+ * Utility wrapper that hides a component on small screens.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 
 export default ((component: QuartzComponent) => {

--- a/quartz/components/Explorer.tsx
+++ b/quartz/components/Explorer.tsx
@@ -1,3 +1,6 @@
+/**
+ * Interactive folder explorer for browsing notes by path.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import style from "./styles/explorer.scss"
 

--- a/quartz/components/Flex.tsx
+++ b/quartz/components/Flex.tsx
@@ -1,3 +1,6 @@
+/**
+ * Layout helper that arranges child components using CSS flexbox.
+ */
 import { concatenateResources } from "../util/resources"
 import { classNames } from "../util/lang"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"

--- a/quartz/components/Footer.tsx
+++ b/quartz/components/Footer.tsx
@@ -1,3 +1,6 @@
+/**
+ * Standard site footer displaying copyright and links.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import style from "./styles/footer.scss"
 import { version } from "../../package.json"

--- a/quartz/components/Graph.tsx
+++ b/quartz/components/Graph.tsx
@@ -1,3 +1,6 @@
+/**
+ * Visualizes the note graph using D3.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 // @ts-ignore
 import script from "./scripts/graph.inline"

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -1,3 +1,6 @@
+/**
+ * Generates the `<head>` element for each page, injecting metadata and resources.
+ */
 import { i18n } from "../i18n"
 import { FullSlug, getFileExtension, joinSegments, pathToRoot } from "../util/path"
 import { CSSResourceToStyleElement, JSResourceToScriptElement } from "../util/resources"

--- a/quartz/components/Header.tsx
+++ b/quartz/components/Header.tsx
@@ -1,3 +1,6 @@
+/**
+ * Wrapper component for the page header section.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 
 const Header: QuartzComponent = ({ children }: QuartzComponentProps) => {

--- a/quartz/components/MobileOnly.tsx
+++ b/quartz/components/MobileOnly.tsx
@@ -1,3 +1,6 @@
+/**
+ * Helper that hides a component on desktop devices.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 
 export default ((component: QuartzComponent) => {

--- a/quartz/components/OverflowList.tsx
+++ b/quartz/components/OverflowList.tsx
@@ -1,3 +1,6 @@
+/**
+ * Utility component that truncates overflowing lists with a toggle.
+ */
 import { JSX } from "preact"
 
 const OverflowList = ({

--- a/quartz/components/PageList.tsx
+++ b/quartz/components/PageList.tsx
@@ -1,3 +1,6 @@
+/**
+ * Renders a list of pages with optional sorting and date information.
+ */
 import { FullSlug, isFolderPath, resolveRelative } from "../util/path"
 import { QuartzPluginData } from "../plugins/vfile"
 import { Date, getDate } from "./Date"

--- a/quartz/components/PageTitle.tsx
+++ b/quartz/components/PageTitle.tsx
@@ -1,3 +1,6 @@
+/**
+ * Displays the site title linking back to the root of the site.
+ */
 import { pathToRoot } from "../util/path"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import { classNames } from "../util/lang"

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Central export for all built-in UI components.
+ */
 import Content from "./pages/Content"
 import TagContent from "./pages/TagContent"
 import FolderContent from "./pages/FolderContent"

--- a/quartz/components/pages/404.tsx
+++ b/quartz/components/pages/404.tsx
@@ -1,3 +1,6 @@
+/**
+ * Simple component shown for non-existent pages.
+ */
 import { i18n } from "../../i18n"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "../types"
 

--- a/quartz/components/pages/Content.tsx
+++ b/quartz/components/pages/Content.tsx
@@ -1,3 +1,6 @@
+/**
+ * Renders the processed HTML contents of a note.
+ */
 import { ComponentChildren } from "preact"
 import { htmlToJsx } from "../../util/jsx"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "../types"

--- a/quartz/components/pages/FolderContent.tsx
+++ b/quartz/components/pages/FolderContent.tsx
@@ -1,3 +1,6 @@
+/**
+ * List page that shows notes grouped by folder path.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "../types"
 
 import style from "../styles/listPage.scss"

--- a/quartz/components/pages/TagContent.tsx
+++ b/quartz/components/pages/TagContent.tsx
@@ -1,3 +1,6 @@
+/**
+ * Displays all notes associated with a particular tag.
+ */
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "../types"
 import style from "../styles/listPage.scss"
 import { PageList, SortFn } from "../PageList"

--- a/quartz/plugins/emitters/assets.ts
+++ b/quartz/plugins/emitters/assets.ts
@@ -1,3 +1,6 @@
+/**
+ * Copies non-Markdown assets from the content directory to the output.
+ */
 import { FilePath, joinSegments, slugifyFilePath } from "../../util/path"
 import { QuartzEmitterPlugin } from "../types"
 import path from "path"

--- a/quartz/plugins/emitters/contentPage.tsx
+++ b/quartz/plugins/emitters/contentPage.tsx
@@ -1,3 +1,6 @@
+/**
+ * Generates full HTML pages for individual notes using the configured layout.
+ */
 import path from "path"
 import { QuartzEmitterPlugin } from "../types"
 import { QuartzComponentProps } from "../../components/types"

--- a/quartz/plugins/emitters/index.ts
+++ b/quartz/plugins/emitters/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Index of emitter plugins responsible for writing site files.
+ */
 export { ContentPage } from "./contentPage"
 export { TagPage } from "./tagPage"
 export { FolderPage } from "./folderPage"

--- a/quartz/plugins/emitters/static.ts
+++ b/quartz/plugins/emitters/static.ts
@@ -1,3 +1,6 @@
+/**
+ * Emits files found under the built-in `static` directory without modification.
+ */
 import { FilePath, QUARTZ, joinSegments } from "../../util/path"
 import { QuartzEmitterPlugin } from "../types"
 import fs from "fs"

--- a/quartz/plugins/emitters/tagPage.tsx
+++ b/quartz/plugins/emitters/tagPage.tsx
@@ -1,3 +1,6 @@
+/**
+ * Builds pages that list all notes under a specific tag.
+ */
 import { QuartzEmitterPlugin } from "../types"
 import { QuartzComponentProps } from "../../components/types"
 import HeaderConstructor from "../../components/Header"

--- a/quartz/plugins/filters/draft.ts
+++ b/quartz/plugins/filters/draft.ts
@@ -1,3 +1,6 @@
+/**
+ * Filter plugin that excludes notes whose frontmatter sets `draft: true`.
+ */
 import { QuartzFilterPlugin } from "../types"
 
 export const RemoveDrafts: QuartzFilterPlugin<{}> = () => ({

--- a/quartz/plugins/filters/explicit.ts
+++ b/quartz/plugins/filters/explicit.ts
@@ -1,3 +1,7 @@
+/**
+ * Filter plugin that only publishes content when `publish: true` is set
+ * in the file frontmatter.
+ */
 import { QuartzFilterPlugin } from "../types"
 
 export const ExplicitPublish: QuartzFilterPlugin = () => ({

--- a/quartz/plugins/filters/index.ts
+++ b/quartz/plugins/filters/index.ts
@@ -1,2 +1,6 @@
+/**
+ * Index of available filter plugins used to decide if content should be
+ * included in the final site.
+ */
 export { RemoveDrafts } from "./draft"
 export { ExplicitPublish } from "./explicit"

--- a/quartz/plugins/index.ts
+++ b/quartz/plugins/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Collects external CSS, JS, and head fragments from active plugins.
+ *
+ * Plugins can expose additional resources which are aggregated here so that
+ * pages can include them during rendering.
+ */
 import { StaticResources } from "../util/resources"
 import { FilePath, FullSlug } from "../util/path"
 import { BuildCtx } from "../util/ctx"

--- a/quartz/plugins/transformers/citations.ts
+++ b/quartz/plugins/transformers/citations.ts
@@ -1,3 +1,6 @@
+/**
+ * Adds support for bibliography references inside Markdown documents.
+ */
 import rehypeCitation from "rehype-citation"
 import { PluggableList } from "unified"
 import { visit } from "unist-util-visit"

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -1,3 +1,6 @@
+/**
+ * Parses YAML frontmatter and attaches the result to each VFile.
+ */
 import matter from "gray-matter"
 import remarkFrontmatter from "remark-frontmatter"
 import { QuartzTransformerPlugin } from "../types"

--- a/quartz/plugins/transformers/index.ts
+++ b/quartz/plugins/transformers/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Entry point for all Markdown transformer plugins.
+ */
 export { FrontMatter } from "./frontmatter"
 export { GitHubFlavoredMarkdown } from "./gfm"
 export { Citations } from "./citations"

--- a/quartz/plugins/types.ts
+++ b/quartz/plugins/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared type definitions for Quartz plugins.
+ * Defines the structure of transformers, filters, and emitters.
+ */
 import { PluggableList } from "unified"
 import { StaticResources } from "../util/resources"
 import { ProcessedContent } from "./vfile"

--- a/quartz/plugins/vfile.ts
+++ b/quartz/plugins/vfile.ts
@@ -1,3 +1,7 @@
+/**
+ * Helper types for representing plugin input and output.
+ * Markdown files are converted to HTML while preserving VFile metadata.
+ */
 import { Root as HtmlRoot } from "hast"
 import { Root as MdRoot } from "mdast"
 import { Data, VFile } from "vfile"


### PR DESCRIPTION
## Summary
- document build script and plugin index
- add brief module docs across plugins and components to comply with guidelines

## Testing
- `npm test` *(fails: `tsx` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c40a8285883268a3e57c6653d54e0