### PR TITLE
Update baseUrl in Quartz config

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -16,7 +16,7 @@ const config: QuartzConfig = {
       provider: "plausible",
     },
     locale: "en-US",
-    baseUrl: "quartz.jzhao.xyz",
+    baseUrl: "codex.github.io/quartz",
     ignorePatterns: ["private", "templates", ".obsidian"],
     defaultDateType: "modified",
     theme: {


### PR DESCRIPTION
## Summary
- update `baseUrl` to reference GitHub Pages domain

## Testing
- `npm test` *(fails: `tsx` not found because dependencies can't be installed due to Node version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_688c410adc5c832693d98118ce3ef1de