### PR TITLE
Fix build failure by disabling OG image generation

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -89,8 +89,8 @@ const config: QuartzConfig = {
       Plugin.Favicon(),
       Plugin.NoJekyll(),
       Plugin.NotFoundPage(),
-      // Comment out CustomOgImages to speed up build time
-      Plugin.CustomOgImages(),
+      // Commented out CustomOgImages to avoid network fetch during build
+      // Plugin.CustomOgImages(),
     ],
   },
 }


### PR DESCRIPTION
## Summary
- disable `Plugin.CustomOgImages` to avoid network fetch errors during build

## Testing
- `npm test`
- `npx quartz build`


------
https://chatgpt.com/codex/tasks/task_e_688c41120e988326b01e97c1abc0fe43