### PR TITLE
Add setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ npm i
 npx quartz create
 ```
 
+Alternatively, run the provided setup script:
+
+```bash
+./scripts/setup.sh        # macOS/Linux
+./scripts/setup.ps1       # Windows PowerShell
+```
+
 ## Sponsors
 
   <p align="center">

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,25 @@
+#!/usr/bin/env pwsh
+<#$
+.SYNOPSIS
+    Initializes a local Quartz environment.
+#>
+
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+    Write-Error "Node.js is not installed. Please install Node 22+ and rerun."
+    exit 1
+}
+
+if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    Write-Error "npm is not installed. Please install npm 10.9.2+ and rerun."
+    exit 1
+}
+
+$versionString = node -v
+$nodeVersion = [version]$versionString.TrimStart('v')
+if ($nodeVersion.Major -lt 22) {
+    Write-Error "Node.js 22+ required. Found $versionString"
+    exit 1
+}
+
+npm install
+npx quartz create

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Setup script for Quartz
+# Installs dependencies and runs the initial create command.
+set -euo pipefail
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is not installed. Please install Node 22+ and rerun." >&2
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is not installed. Please install npm 10.9.2+ and rerun." >&2
+  exit 1
+fi
+
+REQUIRED_NODE_MAJOR=22
+NODE_MAJOR=$(node -v | sed -E 's/v([0-9]+).*/\1/')
+if [ "$NODE_MAJOR" -lt "$REQUIRED_NODE_MAJOR" ]; then
+  echo "Node.js 22+ required. Found $(node -v)." >&2
+  exit 1
+fi
+
+npm install
+npx quartz create


### PR DESCRIPTION
## Summary
- add cross-platform setup scripts
- document setup script usage in README

## Testing
- `npm test` *(fails: `tsx` not found and Node version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_688c45454974832695b9c80b1307e8e5