### PR TITLE
Fix tsx loader deprecation error

### DIFF
--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --no-deprecation --loader tsx
+#!/usr/bin/env -S node --no-deprecation --import tsx
 import "./util/env.js"
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"


### PR DESCRIPTION
## Summary
- use `--import` flag for tsx runtime

## Testing
- `npm test` *(fails: `tsx: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688c486d28c08326a96f2e9a0b26db3e