### PR TITLE
fix tsx loader usage for Node 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/jackyzha0/quartz.git"
   },
   "scripts": {
-    "quartz": "tsx ./quartz/bootstrap-cli.mjs",
+    "quartz": "node --no-deprecation --import tsx ./quartz/bootstrap-cli.mjs",
     "docs": "npx quartz build --serve -d docs",
     "check": "tsc --noEmit && npx prettier . --check",
     "format": "npx prettier . --write",

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --no-deprecation --loader tsx
+#!/usr/bin/env -S node --no-deprecation --import tsx
 import "./util/env.js"
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"


### PR DESCRIPTION
## Summary
- use `--import` flag for tsx in bootstrap CLI
- update npm script to match new flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c486d28c08326a96f2e9a0b26db3e