### PR TITLE
Fix folderPage locale error

### DIFF
--- a/quartz/i18n/index.ts
+++ b/quartz/i18n/index.ts
@@ -31,6 +31,7 @@ import id from "./locales/id-ID"
 export const TRANSLATIONS = {
   "en-US": enUs,
   "en-GB": enGb,
+  "en-CA": enUs,
   "fr-FR": fr,
   "it-IT": it,
   "ja-JP": ja,


### PR DESCRIPTION
## Summary
- add missing `en-CA` locale mapping in `i18n`

## Testing
- `npm install --ignore-scripts --engine-strict=false --ignore-engines`
- `npm rebuild esbuild`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d5c1c88d88326813d8b5f0f3d1bf9